### PR TITLE
Support for Scalingo 20 stack and sync from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,0 @@
-## 5.0.0
-
-* Update to jemalloc 5
-* LD_PRELOAD now works differently. Previously, you could point it directly to the jemalloc shared library (/app/vendor/jemalloc/lib/libjemalloc.so.1). Now, it's better to let jemalloc do it for you, as noted in the README. You must change this environment variable when upgrading and it is not backwards compatible. If you are not using LD_PRELOAD and instead use jemalloc.sh, no action is required.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,19 @@ ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 clean:
 	rm -rf src/ dist/
 
+console:
+	@echo "Console Help"
+	@echo
+	@echo "Specify a verion to install:"
+	@echo "    echo 5.2.1 > /env/JEMALLOC_VERSION"
+	@echo
+	@echo "To vendor jemalloc:"
+	@echo "    bin/compile /app/ /cache/ /env/"
+	@echo
+
+	@docker run --rm -ti -v $(shell pwd):/buildpack -e "STACK=heroku-18" -w /buildpack heroku/heroku:18-build \
+		bash -c 'mkdir /app /cache /env; exec bash'
+
 # Download missing source archives to ./src/
 src/jemalloc-%.tar.bz2:
 	mkdir -p $$(dirname $@)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: scalingo scalingo-18
+default: scalingo scalingo-18 scalingo-20
 
 VERSION := 5.2.1
 ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -11,28 +11,47 @@ src/jemalloc-%.tar.bz2:
 	mkdir -p $$(dirname $@)
 	curl -fsL https://github.com/jemalloc/jemalloc/releases/download/$*/jemalloc-$*.tar.bz2 -o $@
 
-.PHONY: scalingo scalingo-18
+.PHONY: scalingo scalingo-18 scalingo-20
 
 # Build for scalingo stack
 scalingo: src/jemalloc-$(VERSION).tar.bz2
 	docker run --rm -it --volume="$(ROOT_DIR):/wrk" \
-		scalingo/builder:v25 /wrk/build.sh $(VERSION) scalingo
+		scalingo/scalingo-14:v33 /wrk/build.sh $(VERSION) scalingo
 
 # Build for scalingo-18 stack
 scalingo-18: src/jemalloc-$(VERSION).tar.bz2
 	docker run --rm -it --volume="$(ROOT_DIR):/wrk" \
-		scalingo/builder-18:v1 /wrk/build.sh $(VERSION) scalingo-18
+		scalingo/scalingo-18:v15 /wrk/build.sh $(VERSION) scalingo-18
+
+# Build for scalingo-20 stack
+scalingo-20: src/jemalloc-$(VERSION).tar.bz2
+	docker run --rm -it --volume="$(ROOT_DIR):/wrk" \
+		scalingo/scalingo-20:v1-alpha2 /wrk/build.sh $(VERSION) scalingo-20
+
+# Build recent releases for scalingo-20 stack
+build-scalingo-20:
+	$(MAKE) scalingo-20 VERSION=3.6.0
+	$(MAKE) scalingo-20 VERSION=4.0.4
+	$(MAKE) scalingo-20 VERSION=4.1.1
+	$(MAKE) scalingo-20 VERSION=4.2.1
+	$(MAKE) scalingo-20 VERSION=4.3.1
+	$(MAKE) scalingo-20 VERSION=4.4.0
+	$(MAKE) scalingo-20 VERSION=4.5.0
+	$(MAKE) scalingo-20 VERSION=5.0.1
+	$(MAKE) scalingo-20 VERSION=5.1.0
+	$(MAKE) scalingo-20 VERSION=5.2.0
+	$(MAKE) scalingo-20 VERSION=5.2.1
 
 # Build recent releases for all supported stacks
-all:
-	$(MAKE) scalingo scalingo-18 VERSION=3.6.0
-	$(MAKE) scalingo scalingo-18 VERSION=4.0.4
-	$(MAKE) scalingo scalingo-18 VERSION=4.1.1
-	$(MAKE) scalingo scalingo-18 VERSION=4.2.1
-	$(MAKE) scalingo scalingo-18 VERSION=4.3.1
-	$(MAKE) scalingo scalingo-18 VERSION=4.4.0
-	$(MAKE) scalingo scalingo-18 VERSION=4.5.0
-	$(MAKE) scalingo scalingo-18 VERSION=5.0.1
-	$(MAKE) scalingo scalingo-18 VERSION=5.1.0
-	$(MAKE) scalingo scalingo-18 VERSION=5.2.0
-	$(MAKE) scalingo scalingo-18 VERSION=5.2.1
+build-all:
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=3.6.0
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.0.4
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.1.1
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.2.1
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.3.1
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.4.0
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.5.0
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=5.0.1
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=5.1.0
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=5.2.0
+	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=5.2.1

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ console:
 	@echo "    bin/compile /app/ /cache/ /env/"
 	@echo
 
-	@docker run --rm -ti -v $(shell pwd):/buildpack -e "STACK=heroku-18" -w /buildpack heroku/heroku:18-build \
+	@docker run --rm -ti -v $(shell pwd):/buildpack -e "STACK=scalingo-20" -w /buildpack scalingo/scalingo:20 \
 		bash -c 'mkdir /app /cache /env; exec bash'
 
 # Download missing source archives to ./src/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: scalingo scalingo-18 scalingo-20
+default: scalingo-14 scalingo-18 scalingo-20
 
 VERSION := 5.2.1
 ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -24,12 +24,12 @@ src/jemalloc-%.tar.bz2:
 	mkdir -p $$(dirname $@)
 	curl -fsL https://github.com/jemalloc/jemalloc/releases/download/$*/jemalloc-$*.tar.bz2 -o $@
 
-.PHONY: scalingo scalingo-18 scalingo-20
+.PHONY: scalingo-14 scalingo-18 scalingo-20
 
 # Build for scalingo stack
-scalingo: src/jemalloc-$(VERSION).tar.bz2
+scalingo-14: src/jemalloc-$(VERSION).tar.bz2
 	docker run --rm -it --volume="$(ROOT_DIR):/wrk" \
-		scalingo/scalingo-14:v33 /wrk/build.sh $(VERSION) scalingo
+		scalingo/scalingo-14:v33 /wrk/build.sh $(VERSION) scalingo-14
 
 # Build for scalingo-18 stack
 scalingo-18: src/jemalloc-$(VERSION).tar.bz2
@@ -57,14 +57,14 @@ build-scalingo-20:
 
 # Build recent releases for all supported stacks
 build-all:
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=3.6.0
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.0.4
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.1.1
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.2.1
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.3.1
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.4.0
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=4.5.0
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=5.0.1
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=5.1.0
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=5.2.0
-	$(MAKE) scalingo scalingo-18 scalingo-20 VERSION=5.2.1
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=3.6.0
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=4.0.4
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=4.1.1
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=4.2.1
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=4.3.1
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=4.4.0
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=4.5.0
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=5.0.1
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=5.1.0
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=5.2.0
+	$(MAKE) scalingo-14 scalingo-18 scalingo-20 VERSION=5.2.1

--- a/README.md
+++ b/README.md
@@ -7,16 +7,30 @@ platforms.
 
 ## Install
 
-```console
+```shell
 scalingo env-set BUILDPACK_URL=https://github.com/Scalingo/multi-buildpack.git
 ```
 
 And in a `.buildpacks` file (example with ruby):
 
-```
+```shell
 https://github.com/Scalingo/jemalloc-buildpack.git
 https://github.com/Scalingo/ruby-buildpack.git
 ```
+
+## Made possible by Dead Man's Snitch
+
+Continued development and support of the jemalloc buildpack is sponsored by
+[Dead Man's Snitch](https://deadmanssnitch.com).
+
+Ever been surprised that a critical recurring job was silently failing to run?
+Whether it's backups, cache clearing, sending invoices, or whatever your
+application depends on, Dead Man's Snitch makes it easy to
+[monitor heroku scheduler](https://deadmanssnitch.com/docs/heroku) tasks or to add
+[cron job monitoring](https://deadmanssnitch.com/docs/cron-job-monitoring) to
+your other services.
+
+Get started for free today with [Dead Man's Snitch on Heroku](https://elements.heroku.com/addons/deadmanssnitch)
 
 ## Usage
 
@@ -25,7 +39,7 @@ https://github.com/Scalingo/ruby-buildpack.git
 Set the JEMALLOC_ENABLED config option to true and jemalloc will be used for
 all commands run inside of your containers.
 
-```console
+```shell
 scalingo env-set JEMALLOC_ENABLED=true
 ```
 
@@ -45,14 +59,14 @@ web: jemalloc.sh bundle exec puma -C config/puma.rb
 
 Set this to true to automatically enable jemalloc.
 
-```console
+```shell
 scalingo env-set JEMALLOC_ENABLED=true
 ```
 
 To disable jemalloc set the option to false. This will cause the application to
 restart disabling jemalloc.
 
-```console
+```shell
 scalingo env-set JEMALLOC_ENABLED=false
 ```
 
@@ -67,46 +81,35 @@ mentioning tar if the version does not exist.
 **note:** This setting is only used during slug compilation. Changing it will
 require a code change to be deployed in order to take affect.
 
-```console
+```shell
 scalingo env-set JEMALLOC_VERSION=3.6.0
 ```
 
 #### Available Versions
 
-| Version                                                          |
-| ---------------------------------------------------------------- |
-| [3.6.0](https://github.com/jemalloc/jemalloc/releases/tag/3.6.0) |
-| [4.0.4](https://github.com/jemalloc/jemalloc/releases/tag/4.0.4) |
-| [4.1.1](https://github.com/jemalloc/jemalloc/releases/tag/4.1.1) |
-| [4.2.1](https://github.com/jemalloc/jemalloc/releases/tag/4.2.1) |
-| [4.3.1](https://github.com/jemalloc/jemalloc/releases/tag/4.3.1) |
-| [4.4.0](https://github.com/jemalloc/jemalloc/releases/tag/4.4.0) |
-| [4.5.0](https://github.com/jemalloc/jemalloc/releases/tag/4.5.0) |
-| [5.0.1](https://github.com/jemalloc/jemalloc/releases/tag/5.0.1) |
-| [5.1.0](https://github.com/jemalloc/jemalloc/releases/tag/5.1.0) |
-| [5.2.0](https://github.com/jemalloc/jemalloc/releases/tag/5.2.0) |
-| [5.2.1](https://github.com/jemalloc/jemalloc/releases/tag/5.2.1) |
+| Version                                                          | Released   |
+| ---------------------------------------------------------------- | ---------- |
+| [3.6.0](https://github.com/jemalloc/jemalloc/releases/tag/3.6.0) | 2015-04-15 |
+| [4.0.4](https://github.com/jemalloc/jemalloc/releases/tag/4.0.4) | 2015-10-24 |
+| [4.1.1](https://github.com/jemalloc/jemalloc/releases/tag/4.1.1) | 2016-05-03 |
+| [4.2.1](https://github.com/jemalloc/jemalloc/releases/tag/4.2.1) | 2016-06-08 |
+| [4.3.1](https://github.com/jemalloc/jemalloc/releases/tag/4.3.1) | 2016-11-07 |
+| [4.4.0](https://github.com/jemalloc/jemalloc/releases/tag/4.4.0) | 2016-12-04 |
+| [4.5.0](https://github.com/jemalloc/jemalloc/releases/tag/4.5.0) | 2017-02-28 |
+| [5.0.1](https://github.com/jemalloc/jemalloc/releases/tag/5.0.1) | 2017-07-01 |
+| [5.1.0](https://github.com/jemalloc/jemalloc/releases/tag/5.1.0) | 2018-05-08 |
+| [5.2.0](https://github.com/jemalloc/jemalloc/releases/tag/5.2.0) | 2019-04-02 |
+| [5.2.1](https://github.com/jemalloc/jemalloc/releases/tag/5.2.1) | 2019-08-05 |
 
 The complete and most up to date list of supported versions and stacks is
 available on the [releases page.](https://github.com/Scalingo/jemalloc-buildpack/releases)
-
-## Thanks
-
-Continued development of the jemalloc buildpack is sponsored by [Dead Man's Snitch](https://deadmanssnitch.com).
-Ever been surprised that a critical scheduled task was silently failing to
-run? Whether it's backups, cache clearing, or sending invoices, Dead Man's Snitch makes it easy to
-[monitor heroku scheduler](https://deadmanssnitch.com/docs/heroku) tasks or to add
-[cron job monitoring](https://deadmanssnitch.com/docs/cron-job-monitoring)
-to your other services.
-
-Get started for free today with [Dead Man's Snitch on Heroku](http://github.com/deadmanssnitch/heroku-buildpack-dms)
 
 ## Building
 
 This uses Docker to build against Scalingo
 [stack-image](https://doc.scalingo.com/platform/internals/base-docker-image#top-of-page)-like images.
 
-```console
+```shell
 make VERSION=5.2.1
 ```
 

--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,10 @@
 # bin/compile <build-dir> <cache-dir> <env-dir>
 set -e
 
+if [ -n "$BUILDPACK_DEBUG" ]; then
+    set -x
+fi
+
 # Parse params
 BUILD_DIR=$1
 CACHE_DIR=$2

--- a/bin/compile
+++ b/bin/compile
@@ -15,16 +15,66 @@ if [ -f $ENV_DIR/JEMALLOC_VERSION ]; then
   version=$(cat $ENV_DIR/JEMALLOC_VERSION)
 fi
 
-url="https://github.com/Scalingo/jemalloc-buildpack/releases/download/$STACK/jemalloc-$version.tar.bz2"
+# dest is the path in the application that jemalloc will be extracted to.
 dest="$BUILD_DIR/vendor/jemalloc"
 
-echo "-----> Vendoring jemalloc $version"
-echo "       Fetching $url"
+# bundle is the full path to the cached jemalloc binaries for this version.
+bundle=$CACHE_DIR/jemalloc/$version
+
+# cached checks to see if there is a compatible version in the cache.
+function cached() {
+  # Returns false when there is no matching version in the cache.
+  if [[ ! -d $bundle ]]; then
+    return 1
+  fi
+
+  if [ -f "$bundle/.stack" ]; then
+    CACHED_STACK=$(cat $bundle/.stack)
+  fi
+
+  # True when the downloaded version in the cache is for the same stack as the
+  # compiling dyno. CACHED_STACK will be empty when the .stack file is missing
+  # which also forces a fresh download.
+  [[ $CACHED_STACK == $STACK ]]
+}
+
+function download_jemalloc() {
+  url="https://github.com/Scalingo/jemalloc-buildpack/releases/download/$STACK/jemalloc-$version.tar.bz2"
+
+  # Disable exit on command failure so we can provide better error messages
+  set +e
+
+  echo "       jemalloc: Fetching $url"
+  status=$(curl -sL -f  -w "%{http_code}" -o /tmp/jemalloc.tar.bz2 $url)
+
+  if [[ $status -ge 300 ]]; then
+    echo " !     jemalloc: Server returned HTTP $status"
+    exit 1
+  fi
+
+  # Reenable exit on failure
+  set -e
+
+  mkdir -p $bundle
+  tar -xj -f /tmp/jemalloc.tar.bz2 -C $bundle
+
+  # Store the stack version (e.g. heroku-20) that was downloaded to force a
+  # redownload should the stack change.
+  echo "$STACK" > "$bundle/.stack"
+}
+
+echo "-----> jemalloc: Vendoring $version"
+
+# Check if this version of jemalloc is in the cache and download it if it
+# doesn't exist.
+if ! cached; then
+  download_jemalloc
+fi
 
 mkdir -p $dest
-curl -sL $url | tar -C $dest -xj
+cp -r $bundle -T $dest/
 
-echo "-----> Building runtime environment"
+echo "-----> jemalloc: Building runtime environment"
 mkdir -p $BUILD_DIR/.profile.d
 
 cat <<'EOF' > $BUILD_DIR/.profile.d/jemalloc.sh


### PR DESCRIPTION
Close #2

- Add Support for Scalingo 20 Stack
- Move scalingo to scalingo-14 (scalingo stack doesn't exist anymore)
- Move scalingo-builder to scalingo stacks images (scalingo-builder doesn't exist anymore)
- Sync from upstream
- Add `BUILDPACK_DEBUG`
I think we can close #3 too. The information provided is not clear enough to determine whether it is broken. Also the intercom link is not specified :/ WDYT ?

After the merge of this PR, I will create the tag scalingo-20 and do the release and test of this buildpack.
